### PR TITLE
feature/pick_up_valuable_signals_automatically

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -36,6 +36,13 @@ if __name__ == '__main__':
     cook.collectTomato(path.join(input_directory, config_data["signal_file"]),
                        config_data['risk_ratio'], config_data['balance'])
     cook.sortInvolvedSignals()
+    cook.identifyPoisonMushroom(config_data["filter"]["relevance"])
+
+    target_criteria = config_data['target_signals']
+    target_signals = cook.pickUpTargetSignals(target_criteria)
+    print 'Target signals: {}'.format(target_signals)
+
+
 
     csv_saver = CSVSaver(path.abspath("outputs"))
 
@@ -46,9 +53,15 @@ if __name__ == '__main__':
     db_config = config_data["db_config"]
     db_saver = DBSaver.createSaver(db_config, cook.getInvolvedSignals())
 
-    savers = [db_saver]
+    savers = [csv_saver]
 
     draftSieve = None
+    drawback_ratio = None
+    exp_return_ratio = None
+    sharp_ratio = None
+    pl_ratio = None
+    max_active_num = None
+
     if 'filter' in config_data:
         drawback_ratio = None if 'drawback_ratio' not in config_data['filter'] else config_data['filter'][
             'drawback_ratio']
@@ -58,11 +71,13 @@ if __name__ == '__main__':
         pl_ratio = None if 'pl_ratio' not in config_data['filter'] else config_data['filter']['pl_ratio']
         max_active_num = None if 'max_active_num' not in config_data['filter'] else config_data['filter'][
             'max_active_num']
-        draftSieve = (drawback_ratio,exp_return_ratio,sharp_ratio,pl_ratio, max_active_num)
+
+    draftSieve = (drawback_ratio,exp_return_ratio,sharp_ratio,pl_ratio, max_active_num, cook.getPoisionMushroom())
+
 
 
     chain = Chain(cook, config_data['cpu_num'], config_data['balance'])
-    chain.doBusiness(config_data['target_signals'], savers, draftSieve)
+    chain.doBusiness(target_signals, savers, draftSieve)
 
     time_elapsed = datetime.now() - start_time
     print "Prediction is completed ........."

--- a/restaurant/Restaurant.py
+++ b/restaurant/Restaurant.py
@@ -46,9 +46,9 @@ def carryOut(task):
 
     sieve = Sieve()
     if draftSieve is not None:
-        drawback_ratio, exp_return_ratio, sharp_ratio, pl_ratio, max_active_num = draftSieve
+        drawback_ratio, exp_return_ratio, sharp_ratio, pl_ratio, max_active_num, poison_mushroom = draftSieve
         sieve = Sieve(drawback_ratio=drawback_ratio, exp_return_ratio=exp_return_ratio,
-                      sharp_ratio=sharp_ratio, pl_ratio=pl_ratio, max_active_num=max_active_num)
+                      sharp_ratio=sharp_ratio, pl_ratio=pl_ratio, max_active_num=max_active_num, poison_mushroom = poison_mushroom)
 
 
     chef = Chef(
@@ -98,7 +98,7 @@ class Restaurant:
         self.balance = balance
         self.task_lock = Lock()
 
-        self.sieve = None
+        self.draftSieve = None
 
     def getTaskLock(self):
         return self.task_lock
@@ -118,7 +118,7 @@ class Restaurant:
 
         self.p.map(carryOut, [(st, (
         names_of_signals, references_of_signals, standard_deviation_of_signals, expected_return_of_signals,
-        net_withdrawal_of_signals, relation, balance), self.sieve, full_signals, data_savers) for st in
+        net_withdrawal_of_signals, relation, balance), self.draftSieve, full_signals, data_savers) for st in
                               itertools.chain(taskSequence)])
 
         self.p.close()
@@ -126,4 +126,6 @@ class Restaurant:
 
 
     def setFilter(self, draftSieve):
-        self.sieve = draftSieve
+        self.draftSieve = draftSieve
+
+

--- a/restaurant/Sieve.py
+++ b/restaurant/Sieve.py
@@ -2,12 +2,14 @@
 
 class Sieve:
 
-    def __init__(self, drawback_ratio=None, exp_return_ratio=None, sharp_ratio=None, pl_ratio=None, max_active_num=None):
+    def __init__(self, drawback_ratio=None, exp_return_ratio=None, sharp_ratio=None, pl_ratio=None, max_active_num=None,
+                 poison_mushroom = None):
         self.drawback_ratio = drawback_ratio
         self.exp_return_ratio = exp_return_ratio
         self.sharp_ratio = sharp_ratio
         self.pl_ratio = pl_ratio
         self.max_active_num = max_active_num
+        self.poison_mushroom = poison_mushroom
 
     def filter(self, row):
         flag = True
@@ -33,6 +35,17 @@ class Sieve:
 
         if self.max_active_num is not None and u'active_num' in row.index:
             flag = (row[u'active_num'] <= self.max_active_num) and flag
+
+
+        if self.poison_mushroom is not None and len(self.poison_mushroom) > 0:
+            isPoisonous = False
+            for (left, right) in self.poison_mushroom:
+                if (left in row.index and right in row.index ) and (row[left] > 0 and row[right] > 0):
+                    isPoisonous = True
+                    break
+
+            flag = (not isPoisonous) and flag
+
         return flag
 
 

--- a/restaurant/SmallTask.py
+++ b/restaurant/SmallTask.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from itertools import product
 from itertools import islice
+from itertools import product
+
 from Utils import compareListIgnoreOrder
-import math
+
 
 def calculate_record_size(columns_seeds):
     total = 1
@@ -30,7 +31,7 @@ class SmallTask:
     def generateNextTask(self):
 
         nextTask = SmallTask(self.no, self.column_names, self.column_seeds, start=self.stop,
-                         default_page_size=self.page_size)
+                             default_page_size=self.page_size)
 
         self.stop = self.stop + self.page_size
         return nextTask;
@@ -40,11 +41,10 @@ class SmallTask:
 
     def __next__(self):
 
-        if  self.isDone():
+        if self.isDone():
             raise StopIteration;
 
         return self if self.isSeed else self.generateNextTask()
-
 
     def generateDataSource(self):
         return product(*self.column_seeds)
@@ -55,7 +55,7 @@ class SmallTask:
         return frame
 
     def isDone(self):
-        return  self.stop >= self.record_size
+        return self.stop >= self.record_size
 
     def isComplete(self):
         return self.is_complete

--- a/tests/unit/test_cook.py
+++ b/tests/unit/test_cook.py
@@ -11,6 +11,10 @@ from restaurant.Utils import compareListIgnoreOrder
 
 
 class CookTest(unittest.TestCase):
+    def test_collectTomato(self):
+        hm = Cook()
+        hm.collectTomato(path.abspath("resources/signals.xlsx"))
+
 
     def test_getSignalsInRelation_after_collectPotato(self):
         expect_columns = [u'CJM622', u'CJM815', u'CJM995', u'DEMOZ', u'DM0066', u'DM8034', u'USG']


### PR DESCRIPTION
1. 关于信号的筛选
1.1. 原来是在配置文件中列出选用哪些信号进行计算
1.2. 现在改成从signals.xls配置文件中根据条件自动选出信号列表进行计算
1.3. 增加配置变量：
方差倍数：过滤大于该值的信号（举例：方差倍数=4，则第一个信号 CJM729的方差倍数列值为3.73，<4，所以选取该信号参加计算；而第二个信号CJM911的方差倍数为4.37, >4, 所以第二个信号不参与计算）
信号运行月份 = 检查日期 - 运行开始：过滤小于该预设值的信号（举例：设置此值=4, 第一个信号CJM729的检查日期为2019/6/26，运行开始为2019/3/6，相减后得到天数再除以22.5，得到该信号已经运行月份3.73个月, < 4，则该信号不参与计算。而第四个信号DM8034，同样计算后得到运行月份数15，> 4，选择此信号参与计算）
2. 关于结果的过滤
2.1. 在原来的过滤基础上增加一条根据相关性过滤
相关系数：过滤所有相关系数大于该值的信号组合（举例：设置此值为0.3，relations.xlsx文件中CJM729与CJM911对应的相关系统为0.5862022，> 0.3，则删除所有结果组合中同时出现信号CJM729/CJM911手数同时>0的记录。同理，CJM911/CJM995的对应相关系统值为0.1924926, < 0.3，则保留结果中CJM911/CJM995同时不为零的记录）